### PR TITLE
validateUser 중복 제거

### DIFF
--- a/src/main/java/com/dpide/dpide/service/FileService.java
+++ b/src/main/java/com/dpide/dpide/service/FileService.java
@@ -44,8 +44,6 @@ public class FileService {
 
         Long userId = userService.getAuthenticatedUser(token).getId();
         User user = validateUser(userId);
-
-        validateUser(userId);
         Project project = validateProjectOwnership(projectId, user);
         File parentFile = validateParentFile(req.getParentId());
 
@@ -75,8 +73,6 @@ public class FileService {
 
         Long userId = userService.getAuthenticatedUser(token).getId();
         User user = validateUser(userId);
-
-        validateUser(userId);
         validateProjectOwnership(projectId, user);
 
         File file = fileRepository.findById(fileId)
@@ -114,8 +110,6 @@ public class FileService {
 
         Long userId = userService.getAuthenticatedUser(token).getId();
         User user = validateUser(userId);
-
-        validateUser(userId);
         validateProjectOwnership(projectId, user);
 
         File file = fileRepository.findById(fileId)
@@ -141,8 +135,6 @@ public class FileService {
 
         Long userId = userService.getAuthenticatedUser(token).getId();
         User user = validateUser(userId);
-
-        validateUser(userId);
         validateProjectOwnership(projectId, user);
 
         File file = fileRepository.findById(fileId)


### PR DESCRIPTION
[FileService](diffhunk://#diff-9d1e6cf57a823a0f1e2fced9834845f3d24b6c1bc3e138155fb3ce5251444a54L47-L48): createFile, deleteFile, getFileContent, updateFile 메소드에서 중복된 validateUser 호출을 제거했습니다. [[1]](diffhunk://#diff-9d1e6cf57a823a0f1e2fced9834845f3d24b6c1bc3e138155fb3ce5251444a54L47-L48) [[2]](diffhunk://#diff-9d1e6cf57a823a0f1e2fced9834845f3d24b6c1bc3e138155fb3ce5251444a54L78-L79) [[3]](diffhunk://#diff-9d1e6cf57a823a0f1e2fced9834845f3d24b6c1bc3e138155fb3ce5251444a54L117-L118) [[4]](diffhunk://#diff-9d1e6cf57a823a0f1e2fced9834845f3d24b6c1bc3e138155fb3ce5251444a54L144-L145)